### PR TITLE
PSR-2 and numeric types

### DIFF
--- a/src/Exceptions/SingleTableInheritanceException.php
+++ b/src/Exceptions/SingleTableInheritanceException.php
@@ -2,6 +2,7 @@
 
 namespace Phaza\SingleTableInheritance\Exceptions;
 
-class SingleTableInheritanceException extends \Exception {
+class SingleTableInheritanceException extends \Exception
+{
 
-} 
+}

--- a/src/Exceptions/SingleTableInheritanceInvalidAttributesException.php
+++ b/src/Exceptions/SingleTableInheritanceInvalidAttributesException.php
@@ -2,15 +2,18 @@
 
 namespace Phaza\SingleTableInheritance\Exceptions;
 
-class SingleTableInheritanceInvalidAttributesException extends SingleTableInheritanceException {
-  protected $invalidAttributes;
+class SingleTableInheritanceInvalidAttributesException extends SingleTableInheritanceException
+{
+    protected $invalidAttributes;
 
-  public function __construct($message, array $invalidAttributes) {
-    parent::__construct($message . "The attributes: " . implode(',', $invalidAttributes) . " are invalid.");
-    $this->invalidAttributes = $invalidAttributes;
-  }
+    public function __construct($message, array $invalidAttributes)
+    {
+        parent::__construct($message . "The attributes: " . implode(',', $invalidAttributes) . " are invalid.");
+        $this->invalidAttributes = $invalidAttributes;
+    }
 
-  public function getInvalidAttributes() {
-    return $this->invalidAttributes;
-  }
-} 
+    public function getInvalidAttributes()
+    {
+        return $this->invalidAttributes;
+    }
+}

--- a/src/SingleTableInheritanceObserver.php
+++ b/src/SingleTableInheritanceObserver.php
@@ -2,10 +2,11 @@
 
 namespace Phaza\SingleTableInheritance;
 
-class SingleTableInheritanceObserver {
-
-  public function saving($model) {
-    $model->filterPersistedAttributes();
-    $model->setSingleTableType();
-  }
+class SingleTableInheritanceObserver
+{
+    public function saving($model)
+    {
+        $model->filterPersistedAttributes();
+        $model->setSingleTableType();
+    }
 }

--- a/src/SingleTableInheritanceScope.php
+++ b/src/SingleTableInheritanceScope.php
@@ -6,66 +6,66 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ScopeInterface;
 
-class SingleTableInheritanceScope implements ScopeInterface {
-
-  /**
-   * Apply the scope to a given Eloquent query builder.
-   *
-   * @param  \Illuminate\Database\Eloquent\Builder  $builder
-   * @return void
-   */
-  public function apply(Builder $builder, Model $model) {
-    $subclassTypes = array_keys($model->getSingleTableTypeMap());
-
-    if (!empty($subclassTypes) ) {
-      $builder->whereIn($model->getQualifiedSingleTableTypeColumn(), $subclassTypes);
-    }
-  }
-
-  /**
-   * Remove the scope from the given Eloquent query builder.
-   *
-   * @param  \Illuminate\Database\Eloquent\Builder  $builder
-   * @return void
-   */
-  public function remove(Builder $builder, Model $model) {
-    $column = $model->getQualifiedSingleTableTypeColumn();
-
-    $query = $builder->getQuery();
-
-    $bindings = $query->getRawBindings()['where'];
-    foreach ((array) $query->wheres as $key => $where) {
-      // If the where clause is a single table inheritance in constraint, we will remove it from
-      // the query and reset the keys on the wheres. This allows this developer to
-      // include model in a relationship result set that is lazy loaded.
-
-      if ($this->isSingleTableInheritanceConstraint($where, $column)) {
-        unset($query->wheres[$key]);
-
-        // Assume (naively) that no other scope is binding the same values as the values of our in query.
-        // Not perfect but its about the best we can do without they query keeping better track of which bindings
-        // belong to which where clause.
-        foreach($where['values'] as $value) {
-          if (($binding_key = array_search($value, $bindings)) >= 0) {
-            unset($bindings[$binding_key]);
-          }
+class SingleTableInheritanceScope implements ScopeInterface
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        $subclassTypes = array_keys($model->getSingleTableTypeMap());
+        if (!empty($subclassTypes)) {
+            $builder->whereIn($model->getQualifiedSingleTableTypeColumn(), $subclassTypes);
         }
-
-        $query->setBindings(array_values($bindings));
-        $query->wheres = array_values($query->wheres);
-      }
     }
-  }
 
-  /**
-   * Determine if the given where clause is a single table inheritance constraint.
-   *
-   * @param  array   $where
-   * @param  string  $column
-   * @return bool
-   */
-  protected function isSingleTableInheritanceConstraint(array $where, $column)
-  {
-    return $where['type'] == 'In' && $where['column'] == $column;
-  }
-} 
+    /**
+     * Remove the scope from the given Eloquent query builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @return void
+     */
+    public function remove(Builder $builder, Model $model)
+    {
+        $column = $model->getQualifiedSingleTableTypeColumn();
+
+        $query = $builder->getQuery();
+
+        $bindings = $query->getRawBindings()['where'];
+        foreach ((array) $query->wheres as $key => $where) {
+            // If the where clause is a single table inheritance in constraint, we will remove it from
+            // the query and reset the keys on the wheres. This allows this developer to
+            // include model in a relationship result set that is lazy loaded.
+            if ($this->isSingleTableInheritanceConstraint($where, $column)) {
+                unset($query->wheres[$key]);
+
+                // Assume (naively) that no other scope is binding the same values as the values of our in query.
+                // Not perfect but its about the best we can do without they query keeping better track of which
+                // bindings belong to which where clause.
+                foreach ($where['values'] as $value) {
+                    if (($binding_key = array_search($value, $bindings)) >= 0) {
+                        unset($bindings[$binding_key]);
+                    }
+                }
+
+                $query->setBindings(array_values($bindings));
+                $query->wheres = array_values($query->wheres);
+            }
+        }
+    }
+
+    /**
+     * Determine if the given where clause is a single table inheritance constraint.
+     *
+     * @param  array   $where
+     * @param  string  $column
+     * @return bool
+     */
+    protected function isSingleTableInheritanceConstraint(array $where, $column)
+    {
+        return $where['type'] == 'In' && $where['column'] == $column;
+    }
+}

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -194,9 +194,11 @@ trait SingleTableInheritanceTrait
      */
     public function newFromBuilder($attributes = array(), $connection = null)
     {
+        $attributes = (array)$attributes;
+
         $typeField = static::$singleTableTypeField;
 
-        $classType = isset($attributes->$typeField) ? $attributes->$typeField : null;
+        $classType = ($attributes[$typeField] ?: null);
 
         if ($classType !== null) {
             $childTypes = static::getSingleTableTypeMap();
@@ -211,7 +213,7 @@ trait SingleTableInheritanceTrait
 
             $class = (@$childTypes[$classType] ?: static::class);
             $instance = (new $class)->newInstance([], true);
-            $instance->setFilteredAttributes((array) $attributes);
+            $instance->setFilteredAttributes($attributes);
             $instance->setConnection($connection ?: $this->connection);
 
             return $instance;

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -198,7 +198,7 @@ trait SingleTableInheritanceTrait
 
         $typeField = static::$singleTableTypeField;
 
-        $classType = ($attributes[$typeField] ?: null);
+        $classType = (isset($attributes[$typeField]) ? $attributes[$typeField] : null);
 
         if ($classType !== null) {
             $childTypes = static::getSingleTableTypeMap();

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -198,7 +198,7 @@ trait SingleTableInheritanceTrait
 
         $classType = isset($attributes->$typeField) ? $attributes->$typeField : null;
 
-        if ($classType) {
+        if ($classType !== null) {
             $childTypes = static::getSingleTableTypeMap();
 
             if (!array_key_exists($classType, $childTypes) && empty(static::$singleTableUnrestrictedKeys)) {

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -180,9 +180,10 @@ trait SingleTableInheritanceTrait
             throw new SingleTableInheritanceException(
                 'Cannot save Single table inheritance model without declaring static property $singleTableType.'
             );
-        }
 
-        $this->{static::$singleTableTypeField} = $modelClass::$singleServiceType;
+        } elseif (!isset($this->{static::$singleServiceTypeField})) {
+            $this->{static::$singleTableTypeField} = $modelClass::$singleServiceType;
+        }
     }
 
     /**

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -5,219 +5,259 @@ namespace Phaza\SingleTableInheritance;
 use Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException;
 use Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceInvalidAttributesException;
 
-trait SingleTableInheritanceTrait {
+trait SingleTableInheritanceTrait
+{
+    /**
+     * A cache of all the class types strings to class names.
+     * A map of model class name to map of type to subclass name.
+     *
+     * @var array
+     */
+    protected static $singleTableTypeMap = [];
 
-  /**
-   * A cache of all the class types strings to class names.
-   * A map of model class name to map of type to subclass name.
-   *
-   * @var array
-   */
-  protected static $singleTableTypeMap = [];
+    /**
+     * A cache of all the persisted attributes associated of each class including super class attributes.
+     * A map of model class name to attribute name array.
+     *
+     * @var array
+     */
+    protected static $allPersisted = [];
 
-  /**
-   * A cache of all the persisted attributes associated of each class including super class attributes.
-   * A map of model class name to attribute name array.
-   *
-   * @var array
-   */
-  protected static $allPersisted = [];
+    /**
+     * Boot the trait.
+     *
+     * @return void
+     */
+    public static function bootSingleTableInheritanceTrait()
+    {
 
-  /**
-   * Boot the trait.
-   *
-   * @return void
-   */
-  public static function bootSingleTableInheritanceTrait() {
+        static::getSingleTableTypeMap();
+        static::getAllPersistedAttributes();
 
-    static::getSingleTableTypeMap();
-    static::getAllPersistedAttributes();
+        static::addGlobalScope(new SingleTableInheritanceScope);
 
-    static::addGlobalScope(new SingleTableInheritanceScope);
-
-    static::observe(new SingleTableInheritanceObserver());
-  }
-
-  /**
-   * Get the map of type field values to class names.
-   * @return array the type map
-   */
-  public static function getSingleTableTypeMap() {
-    $calledClass = get_called_class();
-
-    if (array_key_exists($calledClass, self::$singleTableTypeMap) ){
-      return self::$singleTableTypeMap[$calledClass];
+        static::observe(new SingleTableInheritanceObserver());
     }
 
-    $typeMap = [];
+    /**
+     * Get the map of type field values to class names.
+     * @return array the type map
+     */
+    public static function getSingleTableTypeMap()
+    {
+        $calledClass = get_called_class();
 
-    // Check if the calledClass is a leaf of the hierarchy. singleTableSubclasses will be inherited from the parent class
-    // so its important we check for the tableType first otherwise we'd infinitely recurse.
-    if (property_exists($calledClass, 'singleTableType')) {
-      $classType = static::$singleTableType;
-      $typeMap[$classType] = $calledClass;
-    }
-    if (property_exists($calledClass, 'singleTableSubclasses')) {
-      $subclasses = static::$singleTableSubclasses;
-      // prevent infinite recursion if the singleTableSubclasses is inherited
-      if (!in_array($calledClass, $subclasses)) {
-        foreach ($subclasses as $subclass) {
-          $typeMap = array_merge($typeMap, $subclass::getSingleTableTypeMap());
+        if (array_key_exists($calledClass, self::$singleTableTypeMap)) {
+            return self::$singleTableTypeMap[$calledClass];
         }
-      }
-    }
 
-    self::$singleTableTypeMap[$calledClass] = $typeMap;
+        $typeMap = [];
 
-    return $typeMap;
-  }
-
-  /**
-   * Get all the persisted attributes that belongs to the class inheriting values declared on super classes
-   *
-   * @return array
-   */
-  public static function getAllPersistedAttributes() {
-    $calledClass = get_called_class();
-
-    if (array_key_exists($calledClass, self::$allPersisted)) {
-      return self::$allPersisted[$calledClass];
-    } else {
-      $persisted = [];
-      if(property_exists($calledClass, 'persisted')) {
-        $persisted  = $calledClass::$persisted;
-      }
-      $parent = get_parent_class($calledClass);
-      if (method_exists($parent, 'getAllPersistedAttributes')) {
-        $persisted = array_merge($persisted, $parent::getAllPersistedAttributes());
-      }
-    }
-    self::$allPersisted[$calledClass] = $persisted;
-    return self::$allPersisted[$calledClass];
-  }
-
-  /**
-   * Get the list of persisted attributes on this model inheriting values declared on super classes and
-   * including the model's primary key and any date fields.
-   * @return array
-   */
-  public function getPersistedAttributes() {
-    $persisted = static::getAllPersistedAttributes();
-    if (empty($persisted)) {
-      // if the static persisted declaration is empty return empty
-      return [];
-    } else {
-      // otherwise add the instance variables for primaryKey, typeField and dates
-      return array_merge([$this->primaryKey, static::$singleTableTypeField], static::getAllPersistedAttributes(), $this->getDates());
-    }
-  }
-
-  /**
-   * Filter the attributes on the model. Any attribute that is not in the list of persisted attributes will be set to null.
-   * Called before the model is saved to prevent setting spurious data in the database for columns belonging to other models.
-   * If the flag $throwInvalidAttributeExceptions is set to true then this method will throw exceptions if it finds
-   * attributes that are not expected to be persisted.
-   */
-  public function filterPersistedAttributes() {
-    $persisted = $this->getPersistedAttributes();
-    $extraAttributes = null;
-    // if $persisted is empty we don't filter
-    if (!empty($persisted)) {
-      $extraAttributes = array_diff(array_keys($this->attributes), $this->getPersistedAttributes());
-
-      if (!empty($extraAttributes)) {
-        if ($this->getThrowInvalidAttributeExceptions()) {
-          throw new SingleTableInheritanceInvalidAttributesException("Cannot save " . get_called_class() . ".", $extraAttributes);
+        // Check if the calledClass is a leaf of the hierarchy. singleTableSubclasses will be inherited from the
+        // parent class so its important we check for the tableType first otherwise we'd infinitely recurse.
+        if (property_exists($calledClass, 'singleTableType')) {
+            $classType = static::$singleTableType;
+            $typeMap[$classType] = $calledClass;
         }
-        foreach ($extraAttributes as $attribute) {
-          unset($this->attributes[$attribute]);
+
+        if (property_exists($calledClass, 'singleTableSubclasses')) {
+            $subclasses = static::$singleTableSubclasses;
+            // prevent infinite recursion if the singleTableSubclasses is inherited
+            if (!in_array($calledClass, $subclasses)) {
+                foreach ($subclasses as $subclass) {
+                    $typeMap = array_merge($typeMap, $subclass::getSingleTableTypeMap());
+                }
+            }
         }
-      }
-    }
-  }
 
-  /**
-   * Get the list of all types in the hierarchy.
-   * @return array the list of type strings
-   */
-  public function getSingleTableTypes() {
-    return array_keys(static::getSingleTableTypeMap());
-  }
+        self::$singleTableTypeMap[$calledClass] = $typeMap;
 
-  /**
-   * Set the type value into the type field attribute
-   * @throws Exceptions\SingleTableInheritanceException
-   */
-  public function setSingleTableType() {
-    $modelClass = get_class($this);
-    $classType = property_exists($modelClass, 'singleTableType') ? $modelClass::$singleTableType : null;
-    if ($classType) {
-      $this->{static::$singleTableTypeField} = $classType;
-    } else {
-      // We'd like to be able to declare non-leaf classes in the hierarchy as abstract so they can't be instantiated and saved.
-      // However, Eloquent expects to instantiate classes at various points. Therefore throw an exception if we try to save
-      // and instance that doesn't have a type.
-      throw new SingleTableInheritanceException('Cannot save Single table inheritance model without declaring static property $singleTableType.');
-    }
-  }
-
-  /**
-   * Override the Eloquent method to construct a model of the type given by the value of singleTableTypeField
-   * @param array $attributes
-   */
-  public function newFromBuilder($attributes = array(), $connection = null) {
-    $typeField = static::$singleTableTypeField;
-
-    $classType = isset($attributes->$typeField) ? $attributes->$typeField : null;
-
-    if ($classType) {
-      $childTypes = static::getSingleTableTypeMap();
-      if (array_key_exists($classType, $childTypes)) {
-        $class = $childTypes[$classType];
-        $instance = (new $class)->newInstance([], true);
-        $instance->setFilteredAttributes((array) $attributes);
-        $instance->setConnection($connection ?: $this->connection);
-        return $instance;
-      } else {
-        // Throwing either of the exceptions suggests something has gone very wrong with the Global Scope
-        // There is not graceful recovery so complain loudly.
-        throw new SingleTableInheritanceException("Cannot construct newFromBuilder for unrecognized $typeField=$classType");
-      }
-    } else {
-      throw new SingleTableInheritanceException("Cannot construct newFromBuilder without a value for $typeField");
-    }
-  }
-
-  /**
-   * Get the qualified name of the column used to store the class type.
-   * @return string the qualified column name
-   */
-  public function getQualifiedSingleTableTypeColumn() {
-    return $this->getTable() . '.' . static::$singleTableTypeField;
-  }
-
-  public function setFilteredAttributes(array $attributes) {
-    $persistedAttributes = $this->getPersistedAttributes();
-    if (empty($persistedAttributes)) {
-      $filteredAttributes = $attributes;
-    } else {
-      // The query often include a 'select *' from the table which will return null for columns that are not persisted.
-      // If any of those columns are non-null then we need to filter them our or throw and exception if configured.
-      // array_flip is a cute way to do diff/intersection on keys by a non-associative array
-      $extraAttributes = array_filter(array_diff_key($attributes, array_flip($persistedAttributes)), function($value) {
-        return !is_null($value);
-      });
-      if (!empty($extraAttributes) && $this->getThrowInvalidAttributeExceptions()) {
-        throw new SingleTableInheritanceInvalidAttributesException("Cannot construct " . get_called_class() . ".", $extraAttributes);
-      }
-
-      $filteredAttributes = array_intersect_key($attributes, array_flip($persistedAttributes));
+        return $typeMap;
     }
 
-    $this->setRawAttributes($filteredAttributes, true);
-  }
+    /**
+     * Get all the persisted attributes that belongs to the class inheriting values declared on super classes
+     *
+     * @return array
+     */
+    public static function getAllPersistedAttributes()
+    {
+        $calledClass = get_called_class();
 
-  protected function getThrowInvalidAttributeExceptions() {
-    return property_exists(get_called_class(), 'throwInvalidAttributeExceptions') ? static::$throwInvalidAttributeExceptions : false;
-  }
+        if (array_key_exists($calledClass, self::$allPersisted)) {
+            return self::$allPersisted[$calledClass];
+
+        } else {
+            $persisted = [];
+            if (property_exists($calledClass, 'persisted')) {
+                $persisted  = $calledClass::$persisted;
+            }
+            $parent = get_parent_class($calledClass);
+            if (method_exists($parent, 'getAllPersistedAttributes')) {
+                $persisted = array_merge($persisted, $parent::getAllPersistedAttributes());
+            }
+        }
+        self::$allPersisted[$calledClass] = $persisted;
+        return self::$allPersisted[$calledClass];
+    }
+
+    /**
+     * Get the list of persisted attributes on this model inheriting values declared on super classes and
+     * including the model's primary key and any date fields.
+     * @return array
+     */
+    public function getPersistedAttributes()
+    {
+        $persisted = static::getAllPersistedAttributes();
+        if (empty($persisted)) {
+            // if the static persisted declaration is empty return empty
+            return [];
+
+        } else {
+            // otherwise add the instance variables for primaryKey, typeField and dates
+            return array_merge(
+                [$this->primaryKey, static::$singleTableTypeField],
+                static::getAllPersistedAttributes(),
+                $this->getDates()
+            );
+        }
+    }
+
+    /**
+     * Filter the attributes on the model. Any attribute that is not in the list of persisted attributes will
+     * be set to null. Called before the model is saved to prevent setting spurious data in the database for
+     * columns belonging to other models. If the flag $throwInvalidAttributeExceptions is set to true then this
+     * method will throw exceptions if it finds attributes that are not expected to be persisted.
+     */
+    public function filterPersistedAttributes()
+    {
+        $persisted = $this->getPersistedAttributes();
+        $extraAttributes = null;
+
+        // if $persisted is empty we don't filter
+        if (!empty($persisted)) {
+            $extraAttributes = array_diff(array_keys($this->attributes), $this->getPersistedAttributes());
+
+            if (!empty($extraAttributes)) {
+                if ($this->getThrowInvalidAttributeExceptions()) {
+                    throw new SingleTableInheritanceInvalidAttributesException(
+                        "Cannot save " . get_called_class() . ".",
+                        $extraAttributes
+                    );
+                }
+
+                foreach ($extraAttributes as $attribute) {
+                    unset($this->attributes[$attribute]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the list of all types in the hierarchy.
+     * @return array the list of type strings
+     */
+    public function getSingleTableTypes()
+    {
+        return array_keys(static::getSingleTableTypeMap());
+    }
+
+    /**
+     * Set the type value into the type field attribute
+     * @throws Exceptions\SingleTableInheritanceException
+     */
+    public function setSingleTableType()
+    {
+        $modelClass = get_class($this);
+        $classType = (property_exists($modelClass, 'singleTableType') ? $modelClass::$singleTableType : null);
+        if ($classType) {
+            $this->{static::$singleTableTypeField} = $classType;
+
+        } else {
+            // We'd like to be able to declare non-leaf classes in the hierarchy as abstract so they can't be
+            // instantiated and saved. However, Eloquent expects to instantiate classes at various points. Therefore
+            // throw an exception if we try to save and instance that doesn't have a type.
+            throw new SingleTableInheritanceException(
+                'Cannot save Single table inheritance model without declaring static property $singleTableType.'
+            );
+        }
+    }
+
+    /**
+     * Override the Eloquent method to construct a model of the type given by the value of singleTableTypeField
+     * @param array $attributes
+     */
+    public function newFromBuilder($attributes = array(), $connection = null)
+    {
+        $typeField = static::$singleTableTypeField;
+
+        $classType = isset($attributes->$typeField) ? $attributes->$typeField : null;
+
+        if ($classType) {
+            $childTypes = static::getSingleTableTypeMap();
+            if (array_key_exists($classType, $childTypes)) {
+                $class = $childTypes[$classType];
+                $instance = (new $class)->newInstance([], true);
+                $instance->setFilteredAttributes((array) $attributes);
+                $instance->setConnection($connection ?: $this->connection);
+
+                return $instance;
+
+            } else {
+                // Throwing either of the exceptions suggests something has gone very wrong with the Global Scope
+                // There is not graceful recovery so complain loudly.
+                throw new SingleTableInheritanceException(
+                    "Cannot construct newFromBuilder for unrecognized $typeField=$classType"
+                );
+            }
+
+        } else {
+            throw new SingleTableInheritanceException("Cannot construct newFromBuilder without a value for $typeField");
+        }
+    }
+
+    /**
+     * Get the qualified name of the column used to store the class type.
+     * @return string the qualified column name
+     */
+    public function getQualifiedSingleTableTypeColumn()
+    {
+        return $this->getTable() . '.' . static::$singleTableTypeField;
+    }
+
+    public function setFilteredAttributes(array $attributes)
+    {
+        $persistedAttributes = $this->getPersistedAttributes();
+        if (empty($persistedAttributes)) {
+            $filteredAttributes = $attributes;
+        } else {
+            // The query often include a 'select *' from the table which will return null for columns that are not
+            // persisted. If any of those columns are non-null then we need to filter them our or throw and exception
+            // if configured. array_flip is a cute way to do diff/intersection on keys by a non-associative array
+            $extraAttributes = array_filter(
+                array_diff_key($attributes, array_flip($persistedAttributes)),
+                function ($value) {
+                    return !is_null($value);
+                }
+            );
+
+            if (!empty($extraAttributes) && $this->getThrowInvalidAttributeExceptions()) {
+                throw new SingleTableInheritanceInvalidAttributesException(
+                    "Cannot construct " . get_called_class() . ".",
+                    $extraAttributes
+                );
+            }
+
+            $filteredAttributes = array_intersect_key($attributes, array_flip($persistedAttributes));
+        }
+
+        $this->setRawAttributes($filteredAttributes, true);
+    }
+
+    protected function getThrowInvalidAttributeExceptions()
+    {
+        $exists = property_exists(get_called_class(), 'throwInvalidAttributeExceptions');
+
+        return ($exists ? static::$throwInvalidAttributeExceptions : false);
+    }
 }

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -209,7 +209,7 @@ trait SingleTableInheritanceTrait
                 );
             }
 
-            $class = (@$childTypes[$classType] ?: self::class);
+            $class = (@$childTypes[$classType] ?: static::class);
             $instance = (new $class)->newInstance([], true);
             $instance->setFilteredAttributes((array) $attributes);
             $instance->setConnection($connection ?: $this->connection);

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -173,11 +173,7 @@ trait SingleTableInheritanceTrait
     public function setSingleTableType()
     {
         $modelClass = get_class($this);
-        $classType = (property_exists($modelClass, 'singleTableType') ? $modelClass::$singleTableType : null);
-        if ($classType) {
-            $this->{static::$singleTableTypeField} = $classType;
-
-        } else {
+        if (!property_exists($modelClass, 'singleTableType')) {
             // We'd like to be able to declare non-leaf classes in the hierarchy as abstract so they can't be
             // instantiated and saved. However, Eloquent expects to instantiate classes at various points. Therefore
             // throw an exception if we try to save and instance that doesn't have a type.
@@ -185,6 +181,8 @@ trait SingleTableInheritanceTrait
                 'Cannot save Single table inheritance model without declaring static property $singleTableType.'
             );
         }
+
+        $this->{static::$singleTableTypeField} = $modelClass::$singleServiceType;
     }
 
     /**

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -65,7 +65,11 @@ trait SingleTableInheritanceTrait
             // prevent infinite recursion if the singleTableSubclasses is inherited
             if (!in_array($calledClass, $subclasses)) {
                 foreach ($subclasses as $subclass) {
-                    $typeMap = array_merge($typeMap, $subclass::getSingleTableTypeMap());
+
+                    // array_merge() won't work if the singleTableType values are numeric, so we brute-force it.
+                    foreach ($subclass::getSingleTableTypeMap() as $key => $value) {
+                        $typeMap[$key] = $value;
+                    }
                 }
             }
         }

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -181,8 +181,8 @@ trait SingleTableInheritanceTrait
                 'Cannot save Single table inheritance model without declaring static property $singleTableType.'
             );
 
-        } elseif (!isset($this->{static::$singleServiceTypeField})) {
-            $this->{static::$singleTableTypeField} = $modelClass::$singleServiceType;
+        } elseif (!isset($this->{static::$singleTableTypeField})) {
+            $this->{static::$singleTableTypeField} = $modelClass::$singleTableType;
         }
     }
 

--- a/tests/Fixtures/Bike.php
+++ b/tests/Fixtures/Bike.php
@@ -2,9 +2,10 @@
 
 namespace Phaza\SingleTableInheritance\Tests\Fixtures;
 
-class Bike extends Vehicle {
+class Bike extends Vehicle
+{
 
-  protected static $singleTableType = 'bike';
+    protected static $singleTableType = 'bike';
 
-  protected static $throwInvalidAttributeExceptions = true;
+    protected static $throwInvalidAttributeExceptions = true;
 }

--- a/tests/Fixtures/Car.php
+++ b/tests/Fixtures/Car.php
@@ -2,9 +2,10 @@
 
 namespace Phaza\SingleTableInheritance\Tests\Fixtures;
 
-class Car extends MotorVehicle {
+class Car extends MotorVehicle
+{
 
-  protected static $singleTableType = 'car';
+    protected static $singleTableType = 'car';
 
-  protected static $persisted = ['capacity'];
+    protected static $persisted = ['capacity'];
 }

--- a/tests/Fixtures/MotorVehicle.php
+++ b/tests/Fixtures/MotorVehicle.php
@@ -2,14 +2,15 @@
 
 namespace Phaza\SingleTableInheritance\Tests\Fixtures;
 
-class MotorVehicle extends Vehicle {
+class MotorVehicle extends Vehicle
+{
 
-  protected static $singleTableType = 'motorvehicle';
+    protected static $singleTableType = 'motorvehicle';
 
-  protected static $persisted = ['fuel'];
+    protected static $persisted = ['fuel'];
 
-  protected static $singleTableSubclasses = [
+    protected static $singleTableSubclasses = [
     'Phaza\SingleTableInheritance\Tests\Fixtures\Car',
     'Phaza\SingleTableInheritance\Tests\Fixtures\Truck'
-  ];
+    ];
 }

--- a/tests/Fixtures/Truck.php
+++ b/tests/Fixtures/Truck.php
@@ -2,7 +2,8 @@
 
 namespace Phaza\SingleTableInheritance\Tests\Fixtures;
 
-class Truck extends MotorVehicle {
+class Truck extends MotorVehicle
+{
 
-  protected static $singleTableType = 'truck';
+    protected static $singleTableType = 'truck';
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -1,8 +1,10 @@
 <?php
 
 namespace Phaza\SingleTableInheritance\Tests\Fixtures;
+
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
-class User extends Eloquent {
+class User extends Eloquent
+{
 
-} 
+}

--- a/tests/Fixtures/Vehicle.php
+++ b/tests/Fixtures/Vehicle.php
@@ -6,65 +6,69 @@ use Phaza\SingleTableInheritance\SingleTableInheritanceTrait;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use SebastianBergmann\Exporter\Exception;
 
-class Vehicle extends Eloquent {
+class Vehicle extends Eloquent
+{
 
-  use SingleTableInheritanceTrait;
+    use SingleTableInheritanceTrait;
 
-  protected $table = "vehicles";
+    protected $table = "vehicles";
 
-  protected static $singleTableTypeField = 'type';
+    protected static $singleTableTypeField = 'type';
 
-  protected static $persisted = ['color', 'owner_id'];
+    protected static $persisted = ['color', 'owner_id'];
 
-  protected static $singleTableSubclasses = [
-    'Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
-    'Phaza\SingleTableInheritance\Tests\Fixtures\Bike'
-  ];
+    protected static $singleTableSubclasses = [
+        'Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
+        'Phaza\SingleTableInheritance\Tests\Fixtures\Bike'
+    ];
 
-  public function owner()
-  {
-    return $this->belongsTo('Phaza\SingleTableInheritance\Tests\Fixtures\User');
-  }
-
-  // testing hooks to manipulate protected properties from a public context
-  public static function withAllPersisted($persisted, $closure) {
-    $oldPersisted = static::$allPersisted[get_called_class()];
-
-    static::$allPersisted[get_called_class()] = $persisted;
-
-    $result = null;
-    try {
-      $result = $closure();
-    } catch(Exception $e) {
-
+    public function owner()
+    {
+        return $this->belongsTo('Phaza\SingleTableInheritance\Tests\Fixtures\User');
     }
-    static::$allPersisted[get_called_class()] = $oldPersisted;
-    return $result;
-  }
 
-  public static function withTypeField($typeField, $closure) {
-    $oldTypeField = static::$singleTableTypeField;
-    static::$singleTableTypeField = $typeField;
+    // testing hooks to manipulate protected properties from a public context
+    public static function withAllPersisted($persisted, $closure)
+    {
+        $oldPersisted = static::$allPersisted[get_called_class()];
 
-    $result = null;
-    try {
-      $result = $closure();
-    } catch(Exception $e) {
+        static::$allPersisted[get_called_class()] = $persisted;
 
+        $result = null;
+        try {
+            $result = $closure();
+        } catch (Exception $e) {
+        }
+        static::$allPersisted[get_called_class()] = $oldPersisted;
+        return $result;
     }
-    static::$singleTableTypeField = $oldTypeField;
-    return $result;
-  }
 
-  public function setDates(array $dates) {
-    $this->dates = $dates;
-  }
+    public static function withTypeField($typeField, $closure)
+    {
+        $oldTypeField = static::$singleTableTypeField;
+        static::$singleTableTypeField = $typeField;
 
-  public function setPrimaryKey($primaryKey) {
-    $this->primaryKey = $primaryKey;
-  }
+        $result = null;
+        try {
+            $result = $closure();
+        } catch (Exception $e) {
+        }
+        static::$singleTableTypeField = $oldTypeField;
+        return $result;
+    }
 
-  public function setTable($table) {
-    $this->table = $table;
-  }
-} 
+    public function setDates(array $dates)
+    {
+        $this->dates = $dates;
+    }
+
+    public function setPrimaryKey($primaryKey)
+    {
+        $this->primaryKey = $primaryKey;
+    }
+
+    public function setTable($table)
+    {
+        $this->table = $table;
+    }
+}

--- a/tests/SingleTableInheritanceTraitModelMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitModelMethodsTest.php
@@ -15,216 +15,243 @@ use Phaza\SingleTableInheritance\Tests\Fixtures\Vehicle;
  *
  * @package Phaza\SingleTableInheritance\Tests
  */
-class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
+class SingleTableInheritanceTraitModelMethodsTest extends TestCase
+{
 
-  // getPersistedAttributes
+    // getPersistedAttributes
 
-  public function testGetPersistedOfRoot() {
-    $attributes = (new Vehicle)->getPersistedAttributes();
-    sort($attributes);
-    $this->assertEquals(['color', 'created_at', 'id', 'owner_id', 'type', 'updated_at'], $attributes);
-  }
+    public function testGetPersistedOfRoot()
+    {
+        $attributes = (new Vehicle)->getPersistedAttributes();
+        sort($attributes);
+        $this->assertEquals(['color', 'created_at', 'id', 'owner_id', 'type', 'updated_at'], $attributes);
+    }
 
-  public function testGetPersistedOfChild() {
-    $attributes = (new MotorVehicle)->getPersistedAttributes();
-    sort($attributes);
-    $this->assertEquals(['color', 'created_at', 'fuel', 'id', 'owner_id', 'type', 'updated_at'], $attributes);
-  }
+    public function testGetPersistedOfChild()
+    {
+        $attributes = (new MotorVehicle)->getPersistedAttributes();
+        sort($attributes);
+        $this->assertEquals(['color', 'created_at', 'fuel', 'id', 'owner_id', 'type', 'updated_at'], $attributes);
+    }
 
-  public function testGetPersistedOfLeaf() {
-    $attributes = (new Car)->getPersistedAttributes();
-    sort($attributes);
-    $this->assertEquals(['capacity', 'color', 'created_at', 'fuel', 'id', 'owner_id', 'type', 'updated_at'], $attributes);
-  }
+    public function testGetPersistedOfLeaf()
+    {
+        $attributes = (new Car)->getPersistedAttributes();
+        sort($attributes);
+        $this->assertEquals(
+            ['capacity', 'color', 'created_at', 'fuel', 'id', 'owner_id', 'type', 'updated_at'],
+            $attributes
+        );
+    }
 
-  public function testGetPersistedIncludesDates() {
-    $vehicle = new Vehicle;
-    $vehicle->setDates(['purchase_date']);
-    $attributes = $vehicle->getPersistedAttributes();
-    sort($attributes);
-    $this->assertEquals(['color', 'created_at', 'id', 'owner_id', 'purchase_date', 'type', 'updated_at'], $attributes);
-  }
+    public function testGetPersistedIncludesDates()
+    {
+        $vehicle = new Vehicle;
+        $vehicle->setDates(['purchase_date']);
+        $attributes = $vehicle->getPersistedAttributes();
+        sort($attributes);
+        $this->assertEquals(
+            ['color', 'created_at', 'id', 'owner_id', 'purchase_date', 'type', 'updated_at'],
+            $attributes
+        );
+    }
 
-  public function testGetPersistedIncludesPrimaryKey() {
-    $vehicle = new Vehicle;
-    $vehicle->setPrimaryKey('identifier');
-    $attributes = $vehicle->getPersistedAttributes();
-    sort($attributes);
-    $this->assertEquals(['color', 'created_at', 'identifier', 'owner_id', 'type', 'updated_at'], $attributes);
-  }
+    public function testGetPersistedIncludesPrimaryKey()
+    {
+        $vehicle = new Vehicle;
+        $vehicle->setPrimaryKey('identifier');
+        $attributes = $vehicle->getPersistedAttributes();
+        sort($attributes);
+        $this->assertEquals(['color', 'created_at', 'identifier', 'owner_id', 'type', 'updated_at'], $attributes);
+    }
 
-  public function testGetPersistedIsEmptyIfStaticMappingIsNull() {
-    $attributes = Car::withAllPersisted([], function() {
-      return (new Car)->getPersistedAttributes();
-    });
+    public function testGetPersistedIsEmptyIfStaticMappingIsNull()
+    {
+        $attributes = Car::withAllPersisted([], function () {
+            return (new Car)->getPersistedAttributes();
+        });
 
-    $this->assertEquals([], $attributes);
-  }
+        $this->assertEquals([], $attributes);
+    }
 
-  // getQualifiedSingleTableTypeColumn
+    // getQualifiedSingleTableTypeColumn
 
-  public function testGetQualifiedSingleTableTypeColumn() {
-    $car = new Car;
-    $car->setTable('cars');
-    $tableTypeColumn = Car::withTypeField('discriminator', function() use($car) {
-      return $car->getQualifiedSingleTableTypeColumn();
-    });
-    $this->assertEquals('cars.discriminator', $tableTypeColumn);
-  }
+    public function testGetQualifiedSingleTableTypeColumn()
+    {
+        $car = new Car;
+        $car->setTable('cars');
+        $tableTypeColumn = Car::withTypeField('discriminator', function () use ($car) {
+            return $car->getQualifiedSingleTableTypeColumn();
+        });
+        $this->assertEquals('cars.discriminator', $tableTypeColumn);
+    }
 
-  // getSingleTableTypes
+    // getSingleTableTypes
 
-  public function testGetSingleTableTypesOfRoot() {
-    $types = ['motorvehicle', 'car', 'truck', 'bike'];
+    public function testGetSingleTableTypesOfRoot()
+    {
+        $types = ['motorvehicle', 'car', 'truck', 'bike'];
 
-    $this->assertEquals($types, (new Vehicle)->getSingleTableTypes());
-  }
+        $this->assertEquals($types, (new Vehicle)->getSingleTableTypes());
+    }
 
-  public function testGetTypeMapOfChild() {
-    $types = ['motorvehicle', 'car', 'truck'];
+    public function testGetTypeMapOfChild()
+    {
+        $types = ['motorvehicle', 'car', 'truck'];
 
-    $this->assertEquals($types, (new MotorVehicle())->getSingleTableTypes());
-  }
+        $this->assertEquals($types, (new MotorVehicle())->getSingleTableTypes());
+    }
 
-  public function testGetTypeMapOfLeaf() {
-    $types = ['car'];
+    public function testGetTypeMapOfLeaf()
+    {
+        $types = ['car'];
 
-    $this->assertEquals($types, (new Car)->getSingleTableTypes());
-  }
+        $this->assertEquals($types, (new Car)->getSingleTableTypes());
+    }
 
-  // setSingleTableType
+    // setSingleTableType
 
-  public function testSetSingleTableTypeUsesTypeField() {
-    $car = new Car;
-    Car::withTypeField('discriminator', function() use($car) {
-      $car->setSingleTableType();
-    });
+    public function testSetSingleTableTypeUsesTypeField()
+    {
+        $car = new Car;
+        Car::withTypeField('discriminator', function () use ($car) {
+            $car->setSingleTableType();
+        });
 
-    $this->assertEquals('car', $car->getAttributes()['discriminator']);
-  }
+        $this->assertEquals('car', $car->getAttributes()['discriminator']);
+    }
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
-   */
-  public function testSetSingleTableTypeThrowExceptionIfTableTypeIsUnset() {
-    (new Vehicle)->setSingleTableType();
-  }
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
+     */
+    public function testSetSingleTableTypeThrowExceptionIfTableTypeIsUnset()
+    {
+        (new Vehicle)->setSingleTableType();
+    }
 
-  // filterPersistedAttributes
+    // filterPersistedAttributes
 
-  public function testFilterPersistedAttributes() {
-    $car = new Car;
-    $car->fuel = 'diesel';
-    $car->junk = 'trunk';
-    $car->wingspan = 30;
+    public function testFilterPersistedAttributes()
+    {
+        $car = new Car;
+        $car->fuel = 'diesel';
+        $car->junk = 'trunk';
+        $car->wingspan = 30;
 
-    $car->filterPersistedAttributes();
+        $car->filterPersistedAttributes();
 
-    $this->assertEquals(['fuel' => 'diesel'], $car->getAttributes());
-  }
+        $this->assertEquals(['fuel' => 'diesel'], $car->getAttributes());
+    }
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceInvalidAttributesException
-   */
-  public function testFilterPersistedAttributesThrowsIfConfigured() {
-    $bike = new Bike;
-    $bike->fuel = 'diesel';
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceInvalidAttributesException
+     */
+    public function testFilterPersistedAttributesThrowsIfConfigured()
+    {
+        $bike = new Bike;
+        $bike->fuel = 'diesel';
 
-    $bike->filterPersistedAttributes();
-  }
+        $bike->filterPersistedAttributes();
+    }
 
-  public function testFilterPersistedAttributesDoesNothingIfPersistedIsEmpty() {
-    $car = \Mockery::mock('Phaza\SingleTableInheritance\Tests\Fixtures\Car')->makePartial();
+    public function testFilterPersistedAttributesDoesNothingIfPersistedIsEmpty()
+    {
+        $car = \Mockery::mock('Phaza\SingleTableInheritance\Tests\Fixtures\Car')->makePartial();
 
-    $car->shouldReceive('getPersistedAttributes')
-      ->once()
-      ->andReturn([]);
+        $car->shouldReceive('getPersistedAttributes')
+        ->once()
+        ->andReturn([]);
 
-    $car->fuel = 'diesel';
-    $car->junk = 'trunk';
-    $car->wingspan = 30;
+        $car->fuel = 'diesel';
+        $car->junk = 'trunk';
+        $car->wingspan = 30;
 
-    $car->filterPersistedAttributes();
+        $car->filterPersistedAttributes();
 
-    $this->assertEquals(['fuel' => 'diesel','junk' => 'trunk', 'wingspan' => 30], $car->getAttributes());
-  }
+        $this->assertEquals(['fuel' => 'diesel','junk' => 'trunk', 'wingspan' => 30], $car->getAttributes());
+    }
 
-  // setFilteredAttributes
+    // setFilteredAttributes
 
-  public function testSetFilteredAttributes() {
-    $car = new Car;
-    $car->setFilteredAttributes(['fuel' => 'diesel','junk' => 'trunk', 'wingspan' => 30]);
+    public function testSetFilteredAttributes()
+    {
+        $car = new Car;
+        $car->setFilteredAttributes(['fuel' => 'diesel','junk' => 'trunk', 'wingspan' => 30]);
 
-    $this->assertEquals(['fuel' => 'diesel'], $car->getAttributes());
-  }
+        $this->assertEquals(['fuel' => 'diesel'], $car->getAttributes());
+    }
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceInvalidAttributesException
-   */
-  public function testSetFilteredAttributeshrowsIfConfigured() {
-    $bike = new Bike;
-    $bike->setFilteredAttributes(['fuel' => 'diesel']);
-  }
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceInvalidAttributesException
+     */
+    public function testSetFilteredAttributeshrowsIfConfigured()
+    {
+        $bike = new Bike;
+        $bike->setFilteredAttributes(['fuel' => 'diesel']);
+    }
 
-  public function testSetFilteredAttributesDoesNothingIfPersistedIsEmpty() {
-    $car = \Mockery::mock('Phaza\SingleTableInheritance\Tests\Fixtures\Car')->makePartial();
+    public function testSetFilteredAttributesDoesNothingIfPersistedIsEmpty()
+    {
+        $car = \Mockery::mock('Phaza\SingleTableInheritance\Tests\Fixtures\Car')->makePartial();
 
-    $car->shouldReceive('getPersistedAttributes')
-      ->once()
-      ->andReturn([]);
+        $car->shouldReceive('getPersistedAttributes')
+        ->once()
+        ->andReturn([]);
 
-    $car->setFilteredAttributes(['fuel' => 'diesel','junk' => 'trunk', 'wingspan' => 30]);
+        $car->setFilteredAttributes(['fuel' => 'diesel','junk' => 'trunk', 'wingspan' => 30]);
 
-    $this->assertEquals(['fuel' => 'diesel','junk' => 'trunk', 'wingspan' => 30], $car->getAttributes());
-  }
+        $this->assertEquals(['fuel' => 'diesel','junk' => 'trunk', 'wingspan' => 30], $car->getAttributes());
+    }
 
 
-  // newFromBuilder
+    // newFromBuilder
 
-  public function testNewFromBuilder() {
-    $vehicle = new Vehicle;
-    $attr = new \stdClass();
-    $attr->type = 'car';
-    $attr->fuel = 'diesel';
-    $attr->color = 'red';
-    $attr->cruft = 'junk';
+    public function testNewFromBuilder()
+    {
+        $vehicle = new Vehicle;
+        $attr = new \stdClass();
+        $attr->type = 'car';
+        $attr->fuel = 'diesel';
+        $attr->color = 'red';
+        $attr->cruft = 'junk';
 
-    $newVehicle = $vehicle->newFromBuilder($attr);
+        $newVehicle = $vehicle->newFromBuilder($attr);
 
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $newVehicle);
-    $this->assertEquals('diesel', $newVehicle->fuel);
-    $this->assertEquals('red', $newVehicle->color);
-    $this->assertNull($newVehicle->cruft);
-  }
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $newVehicle);
+        $this->assertEquals('diesel', $newVehicle->fuel);
+        $this->assertEquals('red', $newVehicle->color);
+        $this->assertNull($newVehicle->cruft);
+    }
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
-   */
-  public function testNewFromBuilderThrowsIfClassTypeIsUndefined() {
-    $vehicle = new Vehicle;
-    $attr = new \stdClass();
-    $vehicle->newFromBuilder($attr);
-  }
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
+     */
+    public function testNewFromBuilderThrowsIfClassTypeIsUndefined()
+    {
+        $vehicle = new Vehicle;
+        $attr = new \stdClass();
+        $vehicle->newFromBuilder($attr);
+    }
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
-   */
-  public function testNewFromBuilderThrowsIfClassTypeIsNull() {
-    $vehicle = new Vehicle;
-    $attr = new \stdClass();
-    $attr->type = null;
-    $vehicle->newFromBuilder($attr);
-  }
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
+     */
+    public function testNewFromBuilderThrowsIfClassTypeIsNull()
+    {
+        $vehicle = new Vehicle;
+        $attr = new \stdClass();
+        $attr->type = null;
+        $vehicle->newFromBuilder($attr);
+    }
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
-   */
-  public function testNewFromBuilderThrowsIfClassTypeIsUnrecognized() {
-    $vehicle = new Vehicle;
-    $attr = new \stdClass();
-    $attr->type = 'junk';
-    $vehicle->newFromBuilder($attr);
-  }
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
+     */
+    public function testNewFromBuilderThrowsIfClassTypeIsUnrecognized()
+    {
+        $vehicle = new Vehicle;
+        $attr = new \stdClass();
+        $attr->type = 'junk';
+        $vehicle->newFromBuilder($attr);
+    }
 }
-
-

--- a/tests/SingleTableInheritanceTraitPersistenceTest.php
+++ b/tests/SingleTableInheritanceTraitPersistenceTest.php
@@ -17,76 +17,82 @@ use Phaza\SingleTableInheritance\Tests\Fixtures\User;
  *
  * @package Phaza\SingleTableInheritance\Tests
  */
-class SingleTableInheritanceTraitPersistenceTest extends TestCase {
+class SingleTableInheritanceTraitPersistenceTest extends TestCase
+{
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
-   */
-  public function testSavingThrowsExceptionIfModelHasNoClassType() {
-    (new Vehicle())->save();
-  }
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
+     */
+    public function testSavingThrowsExceptionIfModelHasNoClassType()
+    {
+        (new Vehicle())->save();
+    }
 
-  public function testOnlyPersistedAttributesAreSaved() {
-    $car = new Car;
-    $car->color = 'red';
-    $car->fuel = 'unleaded';
-    $car->cruft = 'red is my favorite';
+    public function testOnlyPersistedAttributesAreSaved()
+    {
+        $car = new Car;
+        $car->color = 'red';
+        $car->fuel = 'unleaded';
+        $car->cruft = 'red is my favorite';
 
-    $car->save();
+        $car->save();
 
-    $dbCar = DB::table('vehicles')->first();
+        $dbCar = DB::table('vehicles')->first();
 
-    $this->assertEquals($car->id, $dbCar->id);
-    $this->assertNull($dbCar->cruft);
+        $this->assertEquals($car->id, $dbCar->id);
+        $this->assertNull($dbCar->cruft);
 
-    $this->assertEquals('red', $dbCar->color);
-    $this->assertEquals('unleaded', $dbCar->fuel);
-  }
+        $this->assertEquals('red', $dbCar->color);
+        $this->assertEquals('unleaded', $dbCar->fuel);
+    }
 
-  public function testBelongsToRelationForeignKeyIsSaved() {
-    $owner = new User;
-    $owner->name = 'Mickey Mouse';
-    $owner->save();
+    public function testBelongsToRelationForeignKeyIsSaved()
+    {
+        $owner = new User;
+        $owner->name = 'Mickey Mouse';
+        $owner->save();
 
-    $car = new Car;
-    $car->color = 'red';
-    $car->fuel = 'unleaded';
-    $car->cruft = 'red is my favorite';
-    $car->owner()->associate($owner);
-    $car->save();
+        $car = new Car;
+        $car->color = 'red';
+        $car->fuel = 'unleaded';
+        $car->cruft = 'red is my favorite';
+        $car->owner()->associate($owner);
+        $car->save();
 
-    $dbCar = DB::table('vehicles')->first();
+        $dbCar = DB::table('vehicles')->first();
 
-    $this->assertEquals($car->id, $dbCar->id);
-    $this->assertEquals($owner->id, $dbCar->owner_id);
-  }
+        $this->assertEquals($car->id, $dbCar->id);
+        $this->assertEquals($owner->id, $dbCar->owner_id);
+    }
 
-  public function testAllAttributesAreSavedIfPersistedIsEmpty() {
-    $car = new Car;
-    $car->color = 'red';
-    $car->fuel = 'unleaded';
-    $car->cruft = 'red is my favorite';
+    public function testAllAttributesAreSavedIfPersistedIsEmpty()
+    {
+        $car = new Car;
+        $car->color = 'red';
+        $car->fuel = 'unleaded';
+        $car->cruft = 'red is my favorite';
 
-    Car::withAllPersisted([], function() use($car) {
-      $car->save();
-    });
+        Car::withAllPersisted([], function () use ($car) {
+            $car->save();
+        });
 
-    $dbCar = DB::table('vehicles')->first();
+        $dbCar = DB::table('vehicles')->first();
 
-    $this->assertEquals($car->id, $dbCar->id);
-    $this->assertEquals('red is my favorite', $dbCar->cruft);
+        $this->assertEquals($car->id, $dbCar->id);
+        $this->assertEquals('red is my favorite', $dbCar->cruft);
 
-    $this->assertEquals('red', $dbCar->color);
-    $this->assertEquals('unleaded', $dbCar->fuel);
-  }
+        $this->assertEquals('red', $dbCar->color);
+        $this->assertEquals('unleaded', $dbCar->fuel);
+    }
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
-   */
-  public function testSaveThrowsExceptionForInvalidAttributesIfConfigured() {
-    $bike = new Bike;
-    $bike->color = 'red';
-    $bike->cruft = 'red is my favorite';
-    $bike->save();
-  }
-} 
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
+     */
+    public function testSaveThrowsExceptionForInvalidAttributesIfConfigured()
+    {
+        $bike = new Bike;
+        $bike->color = 'red';
+        $bike->cruft = 'red is my favorite';
+        $bike->save();
+    }
+}

--- a/tests/SingleTableInheritanceTraitQueryTest.php
+++ b/tests/SingleTableInheritanceTraitQueryTest.php
@@ -19,190 +19,202 @@ use Phaza\SingleTableInheritance\Tests\Fixtures\Vehicle;
  *
  * @package Phaza\SingleTableInheritance\Tests
  */
-class SingleTableInheritanceTraitQueryTest extends TestCase {
+class SingleTableInheritanceTraitQueryTest extends TestCase
+{
 
-  public function testQueryingOnRoot() {
-    (new MotorVehicle())->save();
-    (new Car())->save();
-    (new Truck())->save();
-    (new Truck())->save();
-    (new Bike())->save();
+    public function testQueryingOnRoot()
+    {
+        (new MotorVehicle())->save();
+        (new Car())->save();
+        (new Truck())->save();
+        (new Truck())->save();
+        (new Bike())->save();
 
-    $results = Vehicle::all();
+        $results = Vehicle::all();
 
-    $this->assertEquals(5, count($results));
+        $this->assertEquals(5, count($results));
 
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle', $results[0]);
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car',          $results[1]);
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Truck',        $results[2]);
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Truck',        $results[3]);
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Bike',         $results[4]);
-  }
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle', $results[0]);
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $results[1]);
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Truck', $results[2]);
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Truck', $results[3]);
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Bike', $results[4]);
+    }
 
-  public function testQueryingOnChild() {
-    (new MotorVehicle())->save();
-    (new Car())->save();
-    (new Truck())->save();
-    (new Truck())->save();
-    (new Bike())->save();
+    public function testQueryingOnChild()
+    {
+        (new MotorVehicle())->save();
+        (new Car())->save();
+        (new Truck())->save();
+        (new Truck())->save();
+        (new Bike())->save();
 
-    $results = MotorVehicle::all();
+        $results = MotorVehicle::all();
 
-    $this->assertEquals(4, count($results));
+        $this->assertEquals(4, count($results));
 
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle', $results[0]);
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car',          $results[1]);
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Truck',        $results[2]);
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Truck',        $results[3]);
-  }
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle', $results[0]);
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $results[1]);
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Truck', $results[2]);
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Truck', $results[3]);
+    }
 
-  public function testQueryingOnLeaf() {
+    public function testQueryingOnLeaf()
+    {
 
-    (new MotorVehicle())->save();
-    (new Car())->save();
-    (new Truck())->save();
-    (new Truck())->save();
-    (new Bike())->save();
+        (new MotorVehicle())->save();
+        (new Car())->save();
+        (new Truck())->save();
+        (new Truck())->save();
+        (new Bike())->save();
 
-    $results = Car::all();
+        $results = Car::all();
 
-    $this->assertEquals(1, count($results));
+        $this->assertEquals(1, count($results));
 
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car',   $results[0]);
-  }
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $results[0]);
+    }
 
-  public function testFindHasToMatchType() {
-    $car = new Car();
-    $car->save();
-    $carId = $car->id;
+    public function testFindHasToMatchType()
+    {
+        $car = new Car();
+        $car->save();
+        $carId = $car->id;
 
-    $this->assertNull(Truck::find($carId));
-  }
+        $this->assertNull(Truck::find($carId));
+    }
 
-  public function testFindWorksThroughParentClass() {
-    $car = new Car();
-    $car->save();
-    $carId = $car->id;
+    public function testFindWorksThroughParentClass()
+    {
+        $car = new Car();
+        $car->save();
+        $carId = $car->id;
 
-    $vehicle = Vehicle::find($carId);
-    $this->assertNotNull($vehicle);
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $vehicle);
-  }
+        $vehicle = Vehicle::find($carId);
+        $this->assertNotNull($vehicle);
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $vehicle);
+    }
 
-  public function testIgnoreRowsWithMismatchingFieldType() {
-    $now = Carbon::now();
+    public function testIgnoreRowsWithMismatchingFieldType()
+    {
+        $now = Carbon::now();
 
-    DB::table('vehicles')->insert([
-      [
+        DB::table('vehicles')->insert([
+        [
         'type'       => 'junk',
         'created_at' => $now,
         'updated_at' => $now
-      ],
-      [
+        ],
+        [
         'type'       => 'car',
         'created_at' => $now,
         'updated_at' => $now
-      ]
-    ]);
+        ]
+        ]);
 
-    $results = Vehicle::all();
-    $this->assertEquals(1, count($results));
+        $results = Vehicle::all();
+        $this->assertEquals(1, count($results));
 
-    $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $results[0]);
-  }
+        $this->assertInstanceOf('Phaza\SingleTableInheritance\Tests\Fixtures\Car', $results[0]);
+    }
 
-  public function testOnlyPersistedAttributesAreReturnedInQuery() {
-    $now = Carbon::now();
+    public function testOnlyPersistedAttributesAreReturnedInQuery()
+    {
+        $now = Carbon::now();
 
-    DB::table('vehicles')->insert([
-      [
+        DB::table('vehicles')->insert([
+        [
         'type'       => 'car',
         'color'      => 'red',
         'cruft'      => 'red is my favorite',
         'owner_id'   => null,
         'created_at' => $now,
         'updated_at' => $now
-      ]
-    ]);
+        ]
+        ]);
 
-    $car = Car::all()->first();
+        $car = Car::all()->first();
 
-    $this->assertNull($car->cruft);
-  }
+        $this->assertNull($car->cruft);
+    }
 
-  public function testPersistedAttributesCanIncludeBelongsToForeignKeys() {
-    $now = Carbon::now();
+    public function testPersistedAttributesCanIncludeBelongsToForeignKeys()
+    {
+        $now = Carbon::now();
 
-    $userId = DB::table('users')->insert([
-      [
+        $userId = DB::table('users')->insert([
+        [
         'name'       => 'Mickey Mouse',
         'created_at' => $now,
         'updated_at' => $now
-      ]
-    ]);
+        ]
+        ]);
 
-    DB::table('vehicles')->insert([
-      [
+        DB::table('vehicles')->insert([
+        [
         'type'       => 'car',
         'color'      => 'red',
         'owner_id'   => $userId,
         'created_at' => $now,
         'updated_at' => $now
-      ]
-    ]);
+        ]
+        ]);
 
-    $car = Car::all()->first();
+        $car = Car::all()->first();
 
-    $this->assertEquals($userId, $car->owner()->first()->id);
-  }
+        $this->assertEquals($userId, $car->owner()->first()->id);
+    }
 
-  public function testEmptyPersistedAttributesReturnsEverythingInQuery() {
-    $now = Carbon::now();
+    public function testEmptyPersistedAttributesReturnsEverythingInQuery()
+    {
+        $now = Carbon::now();
 
-    DB::table('vehicles')->insert([
-      [
+        DB::table('vehicles')->insert([
+        [
         'type'       => 'car',
         'color'      => 'red',
         'cruft'      => 'red is my favorite',
         'owner_id'   => null,
         'created_at' => $now,
         'updated_at' => $now
-      ]
-    ]);
+        ]
+        ]);
 
-    $car = Car::withAllPersisted([], function() {
-      return Car::all()->first();
-    });
+        $car = Car::withAllPersisted([], function () {
+            return Car::all()->first();
+        });
 
-    $this->assertEquals('red is my favorite', $car->cruft);
-  }
+        $this->assertEquals('red is my favorite', $car->cruft);
+    }
 
-  /**
-   * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
-   */
-  public function testQueryThrowsExceptionIfConfigured() {
-    $now = Carbon::now();
+    /**
+     * @expectedException \Phaza\SingleTableInheritance\Exceptions\SingleTableInheritanceException
+     */
+    public function testQueryThrowsExceptionIfConfigured()
+    {
+        $now = Carbon::now();
 
-    DB::table('vehicles')->insert([
-      [
+        DB::table('vehicles')->insert([
+        [
         'type'       => 'bike',
         'color'      => 'red',
         'cruft'      => 'red is my favorite',
         'created_at' => $now,
         'updated_at' => $now
-      ]
-    ]);
+        ]
+        ]);
 
-    Bike::all()->first();
-  }
+        Bike::all()->first();
+    }
 
-  public function testUpdateRemovesScope() {
-    $car = new Car();
-    $car->color = 'red';
-    $car->save();
+    public function testUpdateRemovesScope()
+    {
+        $car = new Car();
+        $car->color = 'red';
+        $car->save();
 
-    $dbCar = Vehicle::where('color', 'red')->first();
-    $dbCar->color = 'green';
-    $this->assertTrue($dbCar->save()); // if the scope doesn't remove bindings this save will throw an exception.
-  }
-} 
+        $dbCar = Vehicle::where('color', 'red')->first();
+        $dbCar->color = 'green';
+        $this->assertTrue($dbCar->save()); // if the scope doesn't remove bindings this save will throw an exception.
+    }
+}

--- a/tests/SingleTableInheritanceTraitStaticMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitStaticMethodsTest.php
@@ -14,58 +14,65 @@ use Phaza\SingleTableInheritance\Tests\Fixtures\Vehicle;
  *
  * @package Phaza\SingleTableInheritance\Tests
  */
-class SingleTableInheritanceTraitStaticMethodsTest extends TestCase {
+class SingleTableInheritanceTraitStaticMethodsTest extends TestCase
+{
 
-  // getSingleTableTypeMap
+    // getSingleTableTypeMap
 
-  public function testGetTypeMapOfRoot() {
-    $expectedSubclassTypes = [
-      'motorvehicle' => 'Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
-      'car'          => 'Phaza\SingleTableInheritance\Tests\Fixtures\Car',
-      'truck'        => 'Phaza\SingleTableInheritance\Tests\Fixtures\Truck',
-      'bike'         => 'Phaza\SingleTableInheritance\Tests\Fixtures\Bike',
+    public function testGetTypeMapOfRoot()
+    {
+        $expectedSubclassTypes = [
+        'motorvehicle' => 'Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
+        'car'          => 'Phaza\SingleTableInheritance\Tests\Fixtures\Car',
+        'truck'        => 'Phaza\SingleTableInheritance\Tests\Fixtures\Truck',
+        'bike'         => 'Phaza\SingleTableInheritance\Tests\Fixtures\Bike',
 
-    ];
+        ];
 
-    $this->assertEquals($expectedSubclassTypes, Vehicle::getSingleTableTypeMap());
-  }
+        $this->assertEquals($expectedSubclassTypes, Vehicle::getSingleTableTypeMap());
+    }
 
-  public function testGetTypeMapOfChild() {
-    $expectedSubclassTypes = [
-      'motorvehicle' => 'Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
-      'car'          => 'Phaza\SingleTableInheritance\Tests\Fixtures\Car',
-      'truck'        => 'Phaza\SingleTableInheritance\Tests\Fixtures\Truck',
-    ];
+    public function testGetTypeMapOfChild()
+    {
+        $expectedSubclassTypes = [
+        'motorvehicle' => 'Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
+        'car'          => 'Phaza\SingleTableInheritance\Tests\Fixtures\Car',
+        'truck'        => 'Phaza\SingleTableInheritance\Tests\Fixtures\Truck',
+        ];
 
-    $this->assertEquals($expectedSubclassTypes, MotorVehicle::getSingleTableTypeMap());
-  }
+        $this->assertEquals($expectedSubclassTypes, MotorVehicle::getSingleTableTypeMap());
+    }
 
-  public function testGetTypeMapOfLeaf() {
+    public function testGetTypeMapOfLeaf()
+    {
 
-    $expectedSubclassTypes = [
-      'car' => 'Phaza\SingleTableInheritance\Tests\Fixtures\Car'
-    ];
+        $expectedSubclassTypes = [
+        'car' => 'Phaza\SingleTableInheritance\Tests\Fixtures\Car'
+        ];
 
-    $this->assertEquals($expectedSubclassTypes, Car::getSingleTableTypeMap());
-  }
+        $this->assertEquals($expectedSubclassTypes, Car::getSingleTableTypeMap());
+    }
 
-  // getAllPersistedAttributes
+    // getAllPersistedAttributes
 
-  public function testGetAllPersistedOfRoot() {
-    $a = Vehicle::getAllPersistedAttributes();
-    sort($a);
-    $this->assertEquals(['color', 'owner_id'], $a);
-  }
+    public function testGetAllPersistedOfRoot()
+    {
+        $a = Vehicle::getAllPersistedAttributes();
+        sort($a);
+        $this->assertEquals(['color', 'owner_id'], $a);
+    }
 
-  public function testGetAllPersistedOfChild() {
-    $a = MotorVehicle::getAllPersistedAttributes();
-    sort($a);
-    $this->assertEquals(['color', 'fuel', 'owner_id'], $a);
-  }
+    public function testGetAllPersistedOfChild()
+    {
+        $a = MotorVehicle::getAllPersistedAttributes();
+        sort($a);
+        $this->assertEquals(['color', 'fuel', 'owner_id'], $a);
+    }
 
-  public function testGetAllPersistedOfLeaf() {
-    $a = Car::getAllPersistedAttributes();
-    sort($a);
-    $this->assertEquals(['capacity', 'color', 'fuel', 'owner_id'], $a);
-  }
-} 
+    public function testGetAllPersistedOfLeaf()
+    {
+        $a = Car::getAllPersistedAttributes();
+        sort($a);
+        $this->assertEquals(['capacity', 'color', 'fuel', 'owner_id'], $a);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,60 +6,63 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use \Orchestra\Testbench\TestCase as OrchestraTestCase;
 
-abstract class TestCase extends OrchestraTestCase {
+abstract class TestCase extends OrchestraTestCase
+{
 
-  /**
-   * Setup the test environment.
-   */
-  public function setUp() {
-    parent::setUp();
+    /**
+     * Setup the test environment.
+     */
+    public function setUp()
+    {
+        parent::setUp();
 
-    // migrations only for testing purpose
-    \Artisan::call('migrate', array(
-      			'--path' => '../tests/migrations',
-      			'--database' => 'testbench',
-      		));
+        // migrations only for testing purpose
+        \Artisan::call('migrate', array(
+                '--path' => '../tests/migrations',
+                '--database' => 'testbench',
+            ));
 
-    // Laravel is dumb. It calls boot only for the first test but wipes out the observers for others
-    // So we call boot ourselves to make event observing work.
+        // Laravel is dumb. It calls boot only for the first test but wipes out the observers for others
+        // So we call boot ourselves to make event observing work.
 
-    // On the first test, we've already booted, so clear out the listeners. If we haven't booted
-    // already, this is a no-op.
-    // https://github.com/laravel/framework/issues/1181#issuecomment-51627220
+        // On the first test, we've already booted, so clear out the listeners. If we haven't booted
+        // already, this is a no-op.
+        // https://github.com/laravel/framework/issues/1181#issuecomment-51627220
 
-    $models = [
-      'Phaza\SingleTableInheritance\Tests\Fixtures\Vehicle',
-      'Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
-      'Phaza\SingleTableInheritance\Tests\Fixtures\Car',
-      'Phaza\SingleTableInheritance\Tests\Fixtures\Truck',
-      'Phaza\SingleTableInheritance\Tests\Fixtures\Bike'
-    ];
-    // Reset each model event listeners.
-    foreach ($models as $model) {
+        $models = [
+            'Phaza\SingleTableInheritance\Tests\Fixtures\Vehicle',
+            'Phaza\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
+            'Phaza\SingleTableInheritance\Tests\Fixtures\Car',
+            'Phaza\SingleTableInheritance\Tests\Fixtures\Truck',
+            'Phaza\SingleTableInheritance\Tests\Fixtures\Bike'
+        ];
 
-      // Flush any existing listeners.
-      call_user_func(array($model, 'flushEventListeners'));
+        // Reset each model event listeners.
+        foreach ($models as $model) {
+            // Flush any existing listeners.
+            call_user_func(array($model, 'flushEventListeners'));
 
-      // Reregister them.
-      call_user_func(array($model, 'boot'));
+            // Reregister them.
+            call_user_func(array($model, 'boot'));
+        }
     }
-  }
 
-  /**
-   * Define environment setup.
-   *
-   * @param  Illuminate\Foundation\Application $app
-   * @return void
-   */
-  protected function getEnvironmentSetUp($app) {
-    // reset base path to point to our package's src directory
-    $app['path.base'] = __DIR__ . '/../src';
+    /**
+     * Define environment setup.
+     *
+     * @param  Illuminate\Foundation\Application $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        // reset base path to point to our package's src directory
+        $app['path.base'] = __DIR__ . '/../src';
 
-    $app['config']->set('database.default', 'testbench');
-    $app['config']->set('database.connections.testbench', array (
-      'driver'   => 'sqlite',
-      'database' => ':memory:',
-      'prefix'   => '',
-    ));
-  }
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', array (
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ));
+    }
 }

--- a/tests/migrations/2014_09_12_210504_create_users_table.php
+++ b/tests/migrations/2014_09_12_210504_create_users_table.php
@@ -2,31 +2,30 @@
 
 use Illuminate\Database\Migrations\Migration;
 
-
-class CreateUsersTable extends Migration {
+class CreateUsersTable extends Migration
+{
 
   /**
    * Run the migrations.
    *
    * @return void
    */
-  public function up()
-  {
-    Schema::create('users', function ($table){
-      $table->increments('id');
-      $table->string('name');
-      $table->timestamps();
-    });
-  }
+    public function up()
+    {
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
 
   /**
    * Reverse the migrations.
    *
    * @return void
    */
-  public function down()
-  {
-    Schema::drop('users');
-  }
-
+    public function down()
+    {
+        Schema::drop('users');
+    }
 }

--- a/tests/migrations/2014_09_12_210504_create_vehicle_table.php
+++ b/tests/migrations/2014_09_12_210504_create_vehicle_table.php
@@ -2,36 +2,35 @@
 
 use Illuminate\Database\Migrations\Migration;
 
-
-class CreateVehicleTable extends Migration {
+class CreateVehicleTable extends Migration
+{
 
   /**
    * Run the migrations.
    *
    * @return void
    */
-  public function up()
-  {
-    Schema::create('vehicles', function ($table){
-      $table->increments('id');
-      $table->string('type');
-      $table->string('color')->nullable();
-      $table->string('fuel')->nullable();
-      $table->integer('capacity')->nullable();
-      $table->string('cruft')->nullable();
-      $table->integer('owner_id')->nullable();
-      $table->timestamps();
-    });
-  }
+    public function up()
+    {
+        Schema::create('vehicles', function ($table) {
+            $table->increments('id');
+            $table->string('type');
+            $table->string('color')->nullable();
+            $table->string('fuel')->nullable();
+            $table->integer('capacity')->nullable();
+            $table->string('cruft')->nullable();
+            $table->integer('owner_id')->nullable();
+            $table->timestamps();
+        });
+    }
 
   /**
    * Reverse the migrations.
    *
    * @return void
    */
-  public function down()
-  {
-    Schema::drop('vehicles');
-  }
-
+    public function down()
+    {
+        Schema::drop('vehicles');
+    }
 }


### PR DESCRIPTION
I've formatted the code according to PSR-2 coding standards (using phpcbf and phpcs).  I'm not sure how you feel about PSR-2 but it's a major movement within the PHP community to promote ease of reading and maintaining PHP code.

I also fixed a bug where the use of array_merge() in the trait's getSingleTableTypeMap() function effectively prevented support for when $singleTableTypeField refers to a numeric column.  This was a major show-stopper for a project I was trying to use it on.  So I replaced array_merge() with a brute-force merge (a single foreach loop.)

The test all still pass, although I haven't added any new ones yet.
